### PR TITLE
progress on option to post entries for multiple accounting years

### DIFF
--- a/tfsoffice/resources/accounts.py
+++ b/tfsoffice/resources/accounts.py
@@ -476,7 +476,8 @@ class Accounts:
         return response
 
     def append_to_list_for_key(self, dictionary, key, new_value):
-        previous_list = dictionary.get(key, [])
-        new_list = previous_list.append(new_value)
-        dictionary[key] = new_list
+        values = dictionary.get(key, [])
+        values.append(new_value)
+        dictionary[key] = values
+
         return dictionary

--- a/tfsoffice/resources/accounts.py
+++ b/tfsoffice/resources/accounts.py
@@ -478,6 +478,6 @@ class Accounts:
     def append_to_list_for_key(self, dictionary, key, new_value):
         values = dictionary.get(key, [])
         values.append(new_value)
-        dictionary[key] = values
+        dictionary[key] = list(set(values))
 
         return dictionary

--- a/tfsoffice/resources/accounts.py
+++ b/tfsoffice/resources/accounts.py
@@ -280,7 +280,7 @@ class Accounts:
             entry_lists.append(
                 [e for e in entries if e.get('stamp_no', None) == stamp_no]
             )
-        
+
         return entry_lists
 
     def create_bundle(self, data, year):
@@ -318,7 +318,8 @@ class Accounts:
         if data.get('save_option', 1) == 1:
             bundle.BundleDirectAccounting = False
 
-        all_entries_in_year = self.select_entries_for_year(data.entries, bundle.YearId)
+        entries_as_flat_list = data.get('entries', [])
+        all_entries_in_year = self.select_entries_for_year(entries_as_flat_list, bundle.YearId)
         entries_in_year_by_invoice = self.partition_entries_by_invoice_stamp_no(all_entries_in_year)
 
         # Get the next available TransactionNo, within a given year


### PR DESCRIPTION
Not yet recommended to merge.

During tests an undocumented error was returned by 24/7 API that suggests different accounting years must be handled via separate stamp numbers (i.e. uploaded Attachments).

This can already be accomplished using the existing library by performing a duplicate upload (and acquiring its stamp number) for each year and performing separate ledger post requests.

It's possible that more information about the error or a change in 24/7 API constraints could allow this PR with its single-stamp-number / multiple bundle approach to succeed, after some further modification.